### PR TITLE
Issue 6, store mentioned data in post meta

### DIFF
--- a/includes/mentionable-autocomplete.php
+++ b/includes/mentionable-autocomplete.php
@@ -9,6 +9,15 @@
 class Mentionable_Autocomplete {
 
 	/**
+	 * Class constructor
+	 *
+	 * @return \Mentionable_Autocomplete
+	 */
+	public function __construct(){
+		add_action( 'wp_ajax_get_mentionable', array( $this, 'handle_ajax' ) );
+	}
+
+	/**
 	 * Handle the aucomplete ajax request
 	 *
 	 * @return json

--- a/includes/mentionable-postmetas.php
+++ b/includes/mentionable-postmetas.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Provides a mechanism logging mentions both in the local post and in posts mentioned
+ *
+ * @package Mentionable
+ * @since Mentionable 0.1.0
+ * @author Topher
+ */
+
+/**
+ * Mentionable meta data management class
+ *
+ * Contains functions for reading and writing mentions in the local post and in posts mentioned
+ *
+ * @class Mentionable_Postmetas
+ * @version 1.0.0
+ * @since 0.1.0
+ * @package Mentionable
+ * @author Topher
+ */
+
+class Mentionable_Postmetas {
+
+
+	/**
+	 * Parses $content looking for the ids of links with data-mentionable in them
+	 *
+	 * @since 0.1.0
+	 * @access private
+	 *
+	 * @return array
+	 */
+	private function get_mentioned_ids( $content ) {
+
+		// set up array
+		$mentioned_ids = array();
+
+		if ( empty( $content ) )
+			return $mentioned_ids;
+
+		// instantiate the DOM browser and get all the 'a' tags
+		$dom = new DOMDocument();
+		$dom->loadHTML( $content );
+		$data_mentionables = $dom->getElementsByTagName( 'a' );
+
+
+		foreach ( $data_mentionables as $data_mentionable ) {
+
+			// clean up the results a little bit
+			$post_id = absint( stripslashes( str_replace( '"' , '' , $data_mentionable->getAttribute( 'data-mentionable' ) ) ) );
+
+			$post_object = get_post( $post_id );
+
+			// make sure we're getting an actual post ID, then pack into output var
+			if ( $post_object )
+				$mentioned_ids[ $post_id ] = true;
+
+		}
+
+		return $mentioned_ids;
+
+	}
+
+}

--- a/includes/mentionable-postmetas.php
+++ b/includes/mentionable-postmetas.php
@@ -1,46 +1,52 @@
 <?php
-
-/**
- * Provides a mechanism logging mentions both in the local post and in posts mentioned
- *
- * @package Mentionable
- * @since Mentionable 0.1.0
- * @author Topher
- */
-
 /**
  * Mentionable meta data management class
- *
+ * Provides a mechanism logging mentions both in the local post and in posts mentioned
  * Contains functions for reading and writing mentions in the local post and in posts mentioned
  *
  * @class Mentionable_Postmetas
  * @version 1.0.0
  * @since 0.1.0
  * @package Mentionable
- * @author Topher
+ * @author X-Team <x-team.com>
+ * @author Topher <topher.derosia@x-team.com>
  */
 
 class Mentionable_Postmetas {
 
 	/**
+	 * Class constructor
+	 *
+	 * @return \Mentionable_Postmetas
+	 */
+	public function __construct(){
+		// Filter content on post save
+		add_action( 'save_post', array( $this, 'update_mention_meta' ), 10, 3 );
+	}
+
+	/**
 	 * Updates meta for current post
 	 *
-	 * @since 0.1.0
+	 * @since  0.1.0
 	 * @access private
+	 *
+	 * @param $post_id
+	 * @param $post
+	 * @param $update
 	 *
 	 * @return null
 	 */
 	public function update_mention_meta( $post_id, $post, $update ) {
 
-		if ( wp_is_post_revision( $post_id ) || ! $update)
+		if ( wp_is_post_revision( $post_id ) || ! $update )
 			return
 
 		$post = get_post( $post_id );
 
-		// go get the post ids mentioned in this post
+		// Go get the post ids mentioned in this post
 		$mentioned_ids = $this->get_mentioned_ids( $post->post_content );
 
-		// stash them in post meta
+		// Stash them in post meta
 		update_post_meta( $post_id, 'mentions', $mentioned_ids );
 
 		foreach ( $mentioned_ids as $mention => $mention_data ) {
@@ -56,40 +62,40 @@ class Mentionable_Postmetas {
 
 	}
 
-
 	/**
 	 * Parses $content looking for the ids of links with data-mentionable in them
 	 *
-	 * @since 0.1.0
+	 * @since  0.1.0
 	 * @access private
+	 *
+	 * @param $content
 	 *
 	 * @return array
 	 */
 	private function get_mentioned_ids( $content ) {
 
-		// set up array
+		// Set up array
 		$mentioned_ids = array();
 
 		if ( empty( $content ) )
 			return $mentioned_ids;
 
-		// instantiate the DOM browser and get all the 'a' tags
+		// Instantiate the DOM browser and get all the 'a' tags
 		$dom = new DOMDocument();
 		$dom->loadHTML( $content );
 		$data_mentionables = $dom->getElementsByTagName( 'a' );
-
 
 		foreach ( $data_mentionables as $data_mentionable ) {
 
 			if ( ! $data_mentionable->hasAttribute( 'data-mentionable' ) )
 				continue;
 
-			// clean up the results a little bit
+			// Clean up the results a little bit
 			$post_id = absint( stripslashes( str_replace( '"' , '' , $data_mentionable->getAttribute( 'data-mentionable' ) ) ) );
 
 			$post_object = get_post( $post_id );
 
-			// make sure we're getting an actual post ID, then pack into output var
+			// Make sure we're getting an actual post ID, then pack into output var
 			if ( $post_object )
 				$mentioned_ids[ $post_id ] = true;
 

--- a/mentionable.php
+++ b/mentionable.php
@@ -102,7 +102,6 @@ class Mentionable {
 		}
 
 		// Filter content on post save
-		//add_action( 'save_post', array( $this, 'update_mention_meta' ) );
 		add_filter( 'content_save_pre', array( $this, 'update_mention_meta' ), 10, 1 );
 
 	}
@@ -246,19 +245,35 @@ class Mentionable {
 
 		global $post;
 
-		$dom = new DOMDocument();
-		$dom->loadHTML($content);
-		$data_mentionables = $dom->getElementsByTagName('a');
-
-
-// heavy debugging
-		foreach ($data_mentionables as $data_mentionable) {
-			print stripslashes(str_replace('"','',$data_mentionable->getAttribute('data-mentionable')));
-		}
-
-exit();
+		$mentioned_ids = self::parse_content( $content );
 
 		return $content;
+
+	}
+
+	/**
+	 * Parses $content looking for the ids of links with data-mentionable in them
+	 *
+	 * @since 0.1.0
+	 * @access private
+	 *
+	 * @return array
+	 */
+	private function parse_content( $content ) {
+
+		$mentioned_ids = array();
+
+		$dom = new DOMDocument();
+		$dom->loadHTML( $content );
+		$data_mentionables = $dom->getElementsByTagName( 'a' );
+
+
+		foreach ( $data_mentionables as $data_mentionable ) {
+			$id = stripslashes( str_replace( '"' , '' , $data_mentionable->getAttribute( 'data-mentionable' ) ) );
+			$mentioned_ids[$id] = true;
+		}
+
+		return $mentioned_ids;
 
 	}
 

--- a/mentionable.php
+++ b/mentionable.php
@@ -101,6 +101,10 @@ class Mentionable {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		}
 
+		// Filter content on post save
+		//add_action( 'save_post', array( $this, 'update_mention_meta' ) );
+		add_filter( 'content_save_pre', array( $this, 'update_mention_meta' ), 10, 1 );
+
 	}
 
 	/**
@@ -230,6 +234,33 @@ class Mentionable {
 		return isset( $current_post_type ) ? $current_post_type : null;
 	}
 
+	/**
+	 * Updates meta for both current and mentioned posts
+	 *
+	 * @since 0.1.0
+	 * @access private
+	 *
+	 * @return string
+	 */
+	public function update_mention_meta( $content ) {
+
+		global $post;
+
+		$dom = new DOMDocument();
+		$dom->loadHTML($content);
+		$data_mentionables = $dom->getElementsByTagName('a');
+
+
+// heavy debugging
+		foreach ($data_mentionables as $data_mentionable) {
+			print stripslashes(str_replace('"','',$data_mentionable->getAttribute('data-mentionable')));
+		}
+
+exit();
+
+		return $content;
+
+	}
 
 	/**
 	 * $options getter

--- a/mentionable.php
+++ b/mentionable.php
@@ -277,12 +277,11 @@ class Mentionable {
 	 */
 	private function get_mentioned_ids( $content ) {
 
+		// set up array
+		$mentioned_ids = array();
 
 		if ( empty( $content ) )
 			return $mentioned_ids;
-
-		// set up array
-		$mentioned_ids = array();
 
 		// instantiate the DOM browser and get all the 'a' tags
 		$dom = new DOMDocument();

--- a/mentionable.php
+++ b/mentionable.php
@@ -102,7 +102,7 @@ class Mentionable {
 		}
 
 		// Filter content on post save
-		add_action( 'post_updated', array( $this, 'update_mention_meta' ), 10, 3 );
+		add_action( 'save_post', array( $this, 'update_mention_meta' ), 10, 3 );
 
 	}
 

--- a/mentionable.php
+++ b/mentionable.php
@@ -53,7 +53,7 @@ class Mentionable {
 	 * @var object
 	 * @access public
 	 */
-	public $mentionable_post_meta;
+	public $mentionable_postmetas;
 
 	/**
 	 * Current admin post_type
@@ -97,29 +97,8 @@ class Mentionable {
 		// Internationalize the text strings used.
 		add_action( 'plugins_loaded', array( $this, 'i18n' ), 2 );
 
-		// Register tmce plugin -- because pluggable.php is loaded after plugin
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
-
-		// Enqueue admin script
-		if ( in_array( self::$current_post_type, self::$options['post_types'] ) ) {
-			// Filter tinymce css to add custom
-			add_filter( 'mce_css', array( $this, 'filter_mce_css' ) );
-
-			// Enqueue admin script
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		}
-
-		// get the class that manages post meta
-		require_once( dirname( __FILE__ ) . '/includes/mentionable-postmetas.php' );
-		$this->mentionable_post_meta = new Mentionable_Postmetas;
-
-		// Filter content on post save
-		add_action( 'save_post', array( $this->mentionable_post_meta, 'update_mention_meta' ), 10, 3 );
-
-	}
-
-
-	private function require_postmeta_file() {
+		// Setup all dependent class
+		add_action( 'plugins_loaded', array( $this, 'setup' ), 3 );
 	}
 
 	/**
@@ -153,6 +132,30 @@ class Mentionable {
 		load_plugin_textdomain( 'mentionable', false, 'mentionable/languages' );
 	}
 
+	/**
+	 * Setup all classes needed for the plugin
+	 *
+	 * @access public
+	 * @action plugins_loaded
+	 * @return void
+	 */
+	public function setup() {
+		// Register tmce plugin -- because pluggable.php is loaded after plugin
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+		// Enqueue admin script
+		if ( in_array( self::$current_post_type, self::$options['post_types'] ) ) {
+			// Filter tinymce css to add custom
+			add_filter( 'mce_css', array( $this, 'filter_mce_css' ) );
+
+			// Enqueue admin script
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+		}
+
+		// Require postmetas class
+		require_once( MENTIONABLE_INCLUDES_DIR . '/' . self::$class_name . '-postmetas.php' );
+		$this->mentionable_postmetas = new Mentionable_Postmetas;
+	}
 
 	/**
 	 * Add the required action and filter after init hook
@@ -174,7 +177,6 @@ class Mentionable {
 		// Add ajax handler for autocomplete action
 		require_once( MENTIONABLE_INCLUDES_DIR . '/' . self::$class_name . '-autocomplete.php' );
 		$this->autocomplete = new Mentionable_Autocomplete();
-		add_action( 'wp_ajax_get_mentionable', array( $this->autocomplete, 'handle_ajax' ) );
 	}
 
 	/**

--- a/mentionable.php
+++ b/mentionable.php
@@ -48,6 +48,14 @@ class Mentionable {
 	public $autocomplete;
 
 	/**
+	 * Poset meta component class
+	 *
+	 * @var object
+	 * @access public
+	 */
+	public $mentionable_post_meta;
+
+	/**
 	 * Current admin post_type
 	 *
 	 * @var string
@@ -84,7 +92,7 @@ class Mentionable {
 		self::$options = apply_filters( 'mentionable_options', self::$options );
 
 		// Set constans needed by the plugin.
-		add_action( 'init', array( $this, 'define_constants' ), 1 );
+		add_action( 'plugins_loaded', array( $this, 'define_constants' ), 1 );
 
 		// Internationalize the text strings used.
 		add_action( 'plugins_loaded', array( $this, 'i18n' ), 2 );
@@ -103,10 +111,10 @@ class Mentionable {
 
 		// get the class that manages post meta
 		require_once( dirname( __FILE__ ) . '/includes/mentionable-postmetas.php' );
-		$mentionable_post_meta = new Mentionable_Postmetas;
+		$this->mentionable_post_meta = new Mentionable_Postmetas;
 
 		// Filter content on post save
-		add_action( 'save_post', array( $mentionable_post_meta, 'update_mention_meta' ), 10, 3 );
+		add_action( 'save_post', array( $this->mentionable_post_meta, 'update_mention_meta' ), 10, 3 );
 
 	}
 

--- a/mentionable.php
+++ b/mentionable.php
@@ -268,26 +268,6 @@ class Mentionable {
 	}
 
 	/**
-	 * Updates meta for mentioned posts
-	 *
-	 * @since 0.1.0
-	 * @access private
-	 *
-	 * @return null
-	 */
-	public function update_mentioned_by_meta() {
-
-		global $post;
-
-		// go get the post ids mentioned in this post
-		$mentioned_ids = self::parse_content( $post->post_content );
-
-		// stash them in post meta
-		update_post_meta( $post->ID, 'mentions', $mentioned_ids );
-
-	}
-
-	/**
 	 * Parses $content looking for the ids of links with data-mentionable in them
 	 *
 	 * @since 0.1.0

--- a/mentionable.php
+++ b/mentionable.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://x-team.com
  * Description:
  * Version: 0.1.0
- * Author: X-Team, Jonathan Bardo
+ * Author: X-Team, Jonathan Bardo, Topher
  * Author URI: http://x-team.com/wordpress/
  * License: GPLv2+
  * Text Domain: mentionable

--- a/mentionable.php
+++ b/mentionable.php
@@ -102,7 +102,7 @@ class Mentionable {
 		}
 
 		// Filter content on post save
-		add_action( 'save_post', array( $this, 'update_mention_meta' ), 99, 1 );
+		add_action( 'save_post', array( $this, 'update_mention_meta' ), 10, 1 );
 
 	}
 
@@ -247,18 +247,29 @@ class Mentionable {
 
 		if ( is_object( $post ) && ( !wp_is_post_revision( $post->ID ) )  ) {
 
-// DEBUG CODE
-print '<pre>';
-print_r($post);
-print_r(get_post_custom($post->ID));
-print '</pre>';
-exit();
 
 			// go get the post ids mentioned in this post
 			$mentioned_ids = self::get_mentioned_ids( $post->post_content );
 
 			// stash them in post meta
 			update_post_meta( $post->ID, 'mentions', $mentioned_ids );
+
+			foreach ( $mentioned_ids as $mention => $mention_data ) {
+
+				$stack = get_post_meta($mention,'mentioned_by');
+
+				if( $post->ID != $mention)
+					$stack[0][$post->ID] = $mention_data;
+
+				update_post_meta( $mention, 'mentioned_by', $stack[0] );
+
+			}
+
+// DEBUG CODE
+//print '<pre>';
+//print_r(get_post_meta($post->ID,'mentioned_by'));
+//print '</pre>';
+//exit();
 
 
 		}

--- a/mentionable.php
+++ b/mentionable.php
@@ -102,7 +102,7 @@ class Mentionable {
 		}
 
 		// Filter content on post save
-		add_action( 'save_post', array( $this, 'update_mention_meta' ), 10, 1 );
+		add_action( 'post_updated', array( $this, 'update_mention_meta' ), 10, 3 );
 
 	}
 
@@ -241,9 +241,9 @@ class Mentionable {
 	 *
 	 * @return null
 	 */
-	public function update_mention_meta( $post_id ) {
+	public function update_mention_meta( $post_id, $post, $update ) {
 
-		if ( wp_is_post_revision( $post_id ) )
+		if ( wp_is_post_revision( $post_id ) || ! $update)
 			return
 
 		$post = get_post( $post_id );
@@ -276,6 +276,10 @@ class Mentionable {
 	 * @return array
 	 */
 	private function get_mentioned_ids( $content ) {
+
+
+		if ( empty( $content ) )
+			return $mentioned_ids;
 
 		// set up array
 		$mentioned_ids = array();

--- a/tests/test-mentionable-postmetas.php
+++ b/tests/test-mentionable-postmetas.php
@@ -32,7 +32,8 @@ class Test_Mentionable_Postmetas extends WP_UnitTestCase {
 	}
 
 	public function test_constructor() {
-		//@todo
+		$this->assertEquals( 10, has_action( 'save_post', array( $this->plugin->mentionable_postmetas, 'update_mention_meta' ) ), 'update_mention_meta action is not defined or has the wrong priority' );
+		$this->assertEquals( 10, has_action( 'pre_post_update', array( $this->plugin->mentionable_postmetas, 'remove_post_meta' ) ), 'remove_post_meta action is not defined or has the wrong priority' );
 	}
 
 }

--- a/tests/test-mentionable-postmetas.php
+++ b/tests/test-mentionable-postmetas.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Verifies that Mentionable_Postmetas class is working properly
+ *
+ * @author X-Team <x-team.com>
+ */
+
+class Test_Mentionable_Postmetas extends WP_UnitTestCase {
+
+	/**
+	 * PHP unit setup function
+	 *
+	 * @return void
+	 */
+	function setUp() {
+		parent::setUp();
+		$this->plugin = $GLOBALS['mentionable'];
+
+		// We need to change user to verify editing option as admin or editor
+		$administrator_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		update_user_option( $administrator_id, 'rich_editing', 'true' );
+		wp_set_current_user( $administrator_id );
+	}
+
+	/**
+	 * Make sure the plugin is initialized with it's global variable
+	 *
+	 * @return void
+	 */
+	public function test_plugin_initialized() {
+		$this->assertFalse( null == $this->plugin->mentionable_postmetas );
+	}
+
+	public function test_constructor() {
+		//@todo
+	}
+
+}

--- a/tests/test-mentionable.php
+++ b/tests/test-mentionable.php
@@ -53,6 +53,8 @@ class Test_Mentionable extends WP_UnitTestCase {
 
 		$this->assertGreaterThan( 0, has_action( 'admin_init', array( $this->plugin, 'admin_init' ) ), 'init action is not defined or has the wrong priority' );
 
+		$this->assertGreaterThan( 0, has_action( 'save_post', array( $this->plugin, 'update_mention_meta' ) ), 'save_post action is not defined or has the wrong priority' );
+
 		$this->assertGreaterThan( 0, has_filter( 'mce_css', array( $this->plugin, 'filter_mce_css' ) ), 'filter_mce_css action is not defined or has the wrong priority' );
 
 		$this->assertGreaterThan( 0, has_action( 'admin_enqueue_scripts', array( $this->plugin, 'admin_enqueue_scripts' ) ), 'admin_enqueue_scripts action is not defined or has the wrong priority' );

--- a/tests/test-mentionable.php
+++ b/tests/test-mentionable.php
@@ -48,16 +48,8 @@ class Test_Mentionable extends WP_UnitTestCase {
 
 	public function test_contructor() {
 		$this->assertEquals( 1, has_action( 'plugins_loaded', array( $this->plugin, 'define_constants' ) ), 'define_constants action is not defined or has the wrong priority' );
-
 		$this->assertEquals( 2, has_action( 'plugins_loaded', array( $this->plugin, 'i18n' ) ), 'i18n action is not defined or has the wrong priority' );
-
-		$this->assertGreaterThan( 0, has_action( 'admin_init', array( $this->plugin, 'admin_init' ) ), 'init action is not defined or has the wrong priority' );
-
-		$this->assertGreaterThan( 0, has_action( 'save_post', array( $this->plugin->mentionable_post_meta, 'update_mention_meta' ) ), 'save_post action is not defined or has the wrong priority' );
-
-		$this->assertGreaterThan( 0, has_filter( 'mce_css', array( $this->plugin, 'filter_mce_css' ) ), 'filter_mce_css action is not defined or has the wrong priority' );
-
-		$this->assertGreaterThan( 0, has_action( 'admin_enqueue_scripts', array( $this->plugin, 'admin_enqueue_scripts' ) ), 'admin_enqueue_scripts action is not defined or has the wrong priority' );
+		$this->assertEquals( 3, has_action( 'plugins_loaded', array( $this->plugin, 'setup' ) ), 'The setup function is not called' );
 	}
 
 
@@ -90,6 +82,21 @@ class Test_Mentionable extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check if all dependent class are loaded
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function test_setup() {
+		$this->assertGreaterThan( 0, has_action( 'admin_init', array( $this->plugin, 'admin_init' ) ), 'init action is not defined or has the wrong priority' );
+		$this->assertGreaterThan( 0, has_filter( 'mce_css', array( $this->plugin, 'filter_mce_css' ) ), 'filter_mce_css action is not defined or has the wrong priority' );
+		$this->assertGreaterThan( 0, has_action( 'admin_enqueue_scripts', array( $this->plugin, 'admin_enqueue_scripts' ) ), 'admin_enqueue_scripts action is not defined or has the wrong priority' );
+		require_once( MENTIONABLE_INCLUDES_DIR . '/mentionable-postmetas.php' );
+		$this->assertInstanceOf( 'Mentionable_Postmetas', $this->plugin->mentionable_postmetas );
+	}
+
+	/**
 	 * Test init action
 	 *
 	 * @since 0.1.0
@@ -100,9 +107,11 @@ class Test_Mentionable extends WP_UnitTestCase {
 		do_action( 'admin_init' );
 
 		$this->assertEquals( 'true', get_user_option( 'rich_editing' ), 'Current user must have rich_editing option on to use this plugin' );
-
 		$this->assertGreaterThan( 0, has_filter( 'mce_external_plugins', array( $this->plugin, 'register_tmce_plugin' ), 'mce_external_plugins must be defined for the plugin to load' ) );
 		$this->assertGreaterThan( 0, has_action( 'wp_ajax_get_mentionable', array( $this->plugin->autocomplete, 'handle_ajax' ) ), 'handle_ajax function must be defined for the plugin to work' );
+		$this->assertTrue( class_exists( 'Mentionable_Autocomplete' ), 'Mentionable_Autocomplete class is not present.' );
+		require_once( MENTIONABLE_INCLUDES_DIR . '/mentionable-autocomplete.php' );
+		$this->assertInstanceOf( 'Mentionable_Autocomplete', $this->plugin->autocomplete );
 	}
 
 	/**

--- a/tests/test-mentionable.php
+++ b/tests/test-mentionable.php
@@ -53,7 +53,7 @@ class Test_Mentionable extends WP_UnitTestCase {
 
 		$this->assertGreaterThan( 0, has_action( 'admin_init', array( $this->plugin, 'admin_init' ) ), 'init action is not defined or has the wrong priority' );
 
-		$this->assertGreaterThan( 0, has_action( 'save_post', array( $this->plugin, 'update_mention_meta' ) ), 'save_post action is not defined or has the wrong priority' );
+		$this->assertGreaterThan( 0, has_action( 'save_post', array( $this->plugin->mentionable_post_meta, 'update_mention_meta' ) ), 'save_post action is not defined or has the wrong priority' );
 
 		$this->assertGreaterThan( 0, has_filter( 'mce_css', array( $this->plugin, 'filter_mce_css' ) ), 'filter_mce_css action is not defined or has the wrong priority' );
 


### PR DESCRIPTION
This is working for storage, but for some reason requires a post to submit twice or it won't update the remote post to tell it it's been mentioned.

Nothing done yet to delete mentions from remote posts.

@gedex could you take a look?

Relates to #6 
